### PR TITLE
Emit input with file

### DIFF
--- a/PictureInput.vue
+++ b/PictureInput.vue
@@ -147,8 +147,9 @@ export default {
       this.getEXIFOrientation(file, (orientation) => {
         this.setOrientation(orientation)
         let reader = new FileReader()
-        reader.onload = (e) => {
+        reader.onload = e => {
           this.image = e.target.result
+          this.$emit('input', e.target.result)
           this.imageObject = new Image()
           this.imageObject.onload = () => {
             this.drawImage(this.imageObject)

--- a/PictureInput.vue
+++ b/PictureInput.vue
@@ -136,6 +136,7 @@ export default {
       }
 
       this.$emit('change')
+      this.$emit('input', files[0])
 
       if (this.supportsPreview) {
         this.loadImage(files[0])
@@ -149,7 +150,6 @@ export default {
         let reader = new FileReader()
         reader.onload = e => {
           this.image = e.target.result
-          this.$emit('input', e.target.result)
           this.imageObject = new Image()
           this.imageObject.onload = () => {
             this.drawImage(this.imageObject)


### PR DESCRIPTION
Emitting the file on input will allow for binding in the parent component, example:
`<picture-input @input="image = $event"></picture-input>`

Downside is that the performance may be effected.