### PR TITLE
Feature/image cover canvas

### DIFF
--- a/PictureInput.vue
+++ b/PictureInput.vue
@@ -26,7 +26,7 @@
       </div>
       <button v-if="imageSelected" @click.prevent="selectImage" :class="buttonClass"><em v-html="strings.change"></em></button>
       <button v-if="imageSelected && removable" @click.prevent="removeImage" :class="removeButtonClass"><em v-html="strings.remove"></em></button>
-      <button v-if="imageSelected && rotatable" @click.prevent="rotateImage" :class="rotateButtonClass"><em v-html="strings.rotate"></em></button>
+      <button v-if="imageSelected && rotatable" @click.prevent="rotateCanvas" :class="rotateButtonClass"><em v-html="strings.rotate"></em></button>
     </div>
     <div v-else>
       <button v-if="!imageSelected" @click.prevent="selectImage" :class="buttonClass">{{ strings.select }}</button>

--- a/PictureInput.vue
+++ b/PictureInput.vue
@@ -17,14 +17,14 @@
             @click.prevent="selectImage"
             :style="{height: previewHeight + 'px'}">
           </canvas>
-        <div v-if="!imageSelected" 
+        <div v-if="!imageSelected"
           class="picture-inner"
             :style="{top: -previewHeight + 'px', marginBottom: -previewHeight + 'px' }">
           <span v-if="supportsDragAndDrop" class="picture-inner-text" v-html="strings.drag"></span>
           <span v-else class="picture-inner-text" v-html="strings.tap"></span>
         </div>
       </div>
-      <button v-if="imageSelected" @click.prevent="selectImage" :class="buttonClass">{{ strings.change }}</button>
+      <button v-if="imageSelected" @click.prevent="selectImage" :class="buttonClass"><em v-html="strings.change"></em></button>
       <button v-if="imageSelected && removable" @click.prevent="removeImage" :class="removeButtonClass"><em v-html="strings.remove"></em></button>
       <button v-if="imageSelected && rotatable" @click.prevent="rotateImage" :class="rotateButtonClass"><em v-html="strings.rotate"></em></button>
     </div>

--- a/PictureInput.vue
+++ b/PictureInput.vue
@@ -25,8 +25,8 @@
         </div>
       </div>
       <button v-if="imageSelected" @click.prevent="selectImage" :class="buttonClass">{{ strings.change }}</button>
-      <button v-if="imageSelected && removable" @click.prevent="removeImage" :class="removeButtonClass">{{ strings.remove }}</button>
-      <button v-if="imageSelected && rotatable" @click.prevent="rotateImage" :class="rotateButtonClass">{{ strings.rotate }}</button>
+      <button v-if="imageSelected && removable" @click.prevent="removeImage" :class="removeButtonClass"><em v-html="strings.remove"></em></button>
+      <button v-if="imageSelected && rotatable" @click.prevent="rotateImage" :class="rotateButtonClass"><em v-html="strings.rotate"></em></button>
     </div>
     <div v-else>
       <button v-if="!imageSelected" @click.prevent="selectImage" :class="buttonClass">{{ strings.select }}</button>

--- a/PictureInput.vue
+++ b/PictureInput.vue
@@ -263,6 +263,52 @@ export default {
         reader.readAsDataURL(file)
       })
     },
+    drawImageProp(ctx, img, x, y, w, h, offsetX, offsetY) {
+      if (arguments.length === 2) {
+        x = y = 0;
+        w = ctx.canvas.width
+        h = ctx.canvas.height
+      }
+
+      // default offset is center
+      offsetX = typeof offsetX === "number" ? offsetX : 0.5
+      offsetY = typeof offsetY === "number" ? offsetY : 0.5
+
+      // keep bounds [0.0, 1.0]
+      if (offsetX < 0) offsetX = 0
+      if (offsetY < 0) offsetY = 0
+      if (offsetX > 1) offsetX = 1
+      if (offsetY > 1) offsetY = 1
+
+      var iw = img.width,
+        ih = img.height,
+        r = Math.min(w / iw, h / ih),
+        nw = iw * r,   // new prop. width
+        nh = ih * r,   // new prop. height
+        cx, cy, cw, ch, ar = 1
+
+      // decide which gap to fill
+      if (nw < w) ar = w / nw
+      if (Math.abs(ar - 1) < 1e-14 && nh < h) ar = h / nh // updated
+      nw *= ar
+      nh *= ar
+
+      // calc source rectangle
+      cw = iw / (nw / w)
+      ch = ih / (nh / h)
+
+      cx = (iw - cw) * offsetX
+      cy = (ih - ch) * offsetY
+
+      // make sure source rectangle is valid
+      if (cx < 0) cx = 0
+      if (cy < 0) cy = 0
+      if (cw > iw) cw = iw
+      if (ch > ih) ch = ih
+
+      // fill image in dest. rectangle
+      ctx.drawImage(img, cx, cy, cw, ch,  x, y, w, h)
+    },
     drawImage (image) {
       this.imageWidth = image.width
       this.imageHeight = image.height
@@ -301,11 +347,8 @@ export default {
         offsetX = -scaledWidth / 2
         offsetY = -scaledHeight / 2
       }
-      this.context.drawImage(image,
-        offsetX * this.pixelRatio,
-        offsetY * this.pixelRatio,
-        scaledWidth * this.pixelRatio,
-        scaledHeight * this.pixelRatio)
+
+      this.drawImageProp(this.context, image)
     },
     selectImage () {
       this.$refs.fileInput.click()


### PR DESCRIPTION
This is a first approach to fix the issue related to the cover functionality:
https://github.com/alessiomaffeis/vue-picture-input/issues/16

Thanks to this StackOverflow answer:
https://stackoverflow.com/questions/21961839/simulation-background-size-cover-in-canvas

But I don't know how to adapt the rotate offset change when this.rotate is True:
```
if (this.rotate) {
 this.context.translate(offsetX * this.pixelRatio, offsetY * this.pixelRatio)
 this.context.translate(scaledWidth / 2 * this.pixelRatio, scaledHeight / 2 * this.pixelRatio)
 this.context.rotate(this.rotate)
 offsetX = -scaledWidth / 2
 offsetY = -scaledHeight / 2
}
```

I tried many way without success...
@alessiomaffeis: do you have any idea?

