### PR TITLE
Fix server side rendering with (not only) Nuxt 

### DIFF
--- a/PictureInput.vue
+++ b/PictureInput.vue
@@ -87,7 +87,8 @@ export default {
       default: 'btn btn-secondary button secondary'
     },
     prefill: {
-      type: [String, File],
+      // check for File API existence, do not fail with server side rendering
+      type: (typeof File === 'undefined') ? [String] : [String, File],
       default: ''
     },
     prefillOptions: {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "vue-template-compiler": "^2.5.13"
   },
   "jest": {
+    "testURL": "http://localhost/",
     "moduleFileExtensions": [
       "js",
       "vue"

--- a/test/PictureInput.spec.js
+++ b/test/PictureInput.spec.js
@@ -1,4 +1,4 @@
-import { shallow } from '@vue/test-utils'
+import { shallowMount } from '@vue/test-utils'
 import { createRenderer } from 'vue-server-renderer'
 
 import PictureInput from '../PictureInput.vue'
@@ -6,7 +6,7 @@ import PictureInput from '../PictureInput.vue'
 describe('PictureInput.vue', () => {
   it('matches snapshot', () => {
     const renderer = createRenderer()
-    const wrapper = shallow(PictureInput)
+    const wrapper = shallowMount(PictureInput)
     renderer.renderToString(wrapper.vm, (err, str) => {
       if (err) throw new Error(err)
       expect(str).toMatchSnapshot()


### PR DESCRIPTION
Fixes https://github.com/nuxt/nuxt.js/issues/995

Browser File API is not available when server side rendering
is used in Nuxt universal app.

This error can't be easilly solved outside vue-picture-input.
Although Nuxt provides variable to distinguish client/server
rendering this bug occurs just by importing PictureInput. Because
conditional input is not easilly possible with ES6 only workaround
is direct patch of PictureInput.

Sadly I don't find easy way how to write test. @vue/test-utils mocks
File object despite vue-server-renderer is used. But in a real Nuxt
app File is undefined.