### PR TITLE
0 height bug: temporary patch

### DIFF
--- a/PictureInput.vue
+++ b/PictureInput.vue
@@ -412,7 +412,7 @@ export default {
     },
     resizeCanvas () {
       let previewRatio = this.canvasWidth / this.canvasHeight
-      let newWidth = this.$refs.container.clientWidthl
+      let newWidth = this.$refs.container.clientWidth
       if( !newWidth ) return false;
       if (!this.toggleAspectRatio && newWidth === this.containerWidth) {
         return false;

--- a/PictureInput.vue
+++ b/PictureInput.vue
@@ -227,9 +227,7 @@ export default {
       this.$emit('click')
     },
     onResize () {
-      this.resizeCanvas()
-
-      if (this.imageObject) {
+      if (this.resizeCanvas() && this.imageObject) {
         this.drawImage(this.imageObject)
       }
     },
@@ -410,13 +408,15 @@ export default {
     },
     resizeCanvas () {
       let previewRatio = this.canvasWidth / this.canvasHeight
-      let newWidth = this.$refs.container.clientWidth
+      let newWidth = this.$refs.container.clientWidthl
+      if( !newWidth ) return false;
       if (!this.toggleAspectRatio && newWidth === this.containerWidth) {
-        return
+        return false;
       }
       this.containerWidth = newWidth
       this.previewWidth = Math.min(this.containerWidth - this.margin * 2, this.canvasWidth)
       this.previewHeight = this.previewWidth / previewRatio
+      return true;
     },
     getOrientation (width, height) {
       let orientation = 'square'

--- a/PictureInput.vue
+++ b/PictureInput.vue
@@ -199,6 +199,10 @@ export default {
 
     this.canvasWidth = this.width
     this.canvasHeight = this.height
+    if( this.width != Number.MAX_SAFE_INTEGER && this.height != Number.MAX_SAFE_INTEGER ) {
+      this.previewWidth = this.width
+      this.previewHeight = this.height
+    }
 
     this.$on('error', this.onError)
   },


### PR DESCRIPTION
This is not great, I'll be the first to say. It's a brute hack to issue #70 to at least allow fixed height components to work around this issue. Now at least elements with "width" and "height" props specified won't be affected by the bug.

In order to properly solve the issue I think there will need to be some significant changes to the way this component works. I think it uses too much JS to size and style it, in places where CSS should be used. But I assume there was a reason for doing it that way, I don't have the time to dig much deeper right now, but this patch will suffice for my own personal project for now.