### PR TITLE
Fetch mode set to no-cors

### DIFF
--- a/PictureInput.vue
+++ b/PictureInput.vue
@@ -520,7 +520,7 @@ export default {
       headers.append('Accept', 'image/*')
       fetch(source, {
         method: 'GET',
-        mode: 'cors',
+        mode: 'no-cors',
         headers: headers
       }).then(response => {
         return response.blob()


### PR DESCRIPTION
Prefill settings, Load image from url fails because of CORS policy.

I've change fetch mode to no-cors on `PictureInput.vue`